### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -144,11 +144,14 @@ const LinkList = styled(List)`
   flex: 1;
 `;
 
-const CollapseMenuItem = styled(MenuItemButton)`
+const CollapseMenuItem = styled(MenuItemButton)<{
+  isSidebarCollapsed: boolean;
+}>`
   display: none;
-
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
+    transform: ${({ isSidebarCollapsed }) =>
+      isSidebarCollapsed && "rotate(180deg)"};
   }
 `;
 
@@ -196,6 +199,7 @@ export function SidebarNavigation() {
               onClick={() => alert("Support")}
             />
             <CollapseMenuItem
+              isSidebarCollapsed={isSidebarCollapsed}
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "prolog-app",
       "version": "14.5.1",
       "dependencies": {
         "@fontsource/inter": "^4.5.7",


### PR DESCRIPTION
Sidebar Navigation arrow now points to the right when collapsed.

<img width="314" alt="Arrow Right" src="https://user-images.githubusercontent.com/69433605/195684419-836bc52a-71af-4576-a9f5-fb491463d00a.png">
