### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed - Refactoring.

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -144,14 +144,11 @@ const LinkList = styled(List)`
   flex: 1;
 `;
 
-const CollapseMenuItem = styled(MenuItemButton)<{
-  isSidebarCollapsed: boolean;
-}>`
+const CollapseMenuItem = styled(MenuItemButton)`
   display: none;
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
-    transform: ${({ isSidebarCollapsed }) =>
-      isSidebarCollapsed && "rotate(180deg)"};
+    transform: ${({ isCollapsed }) => isCollapsed && "rotate(180deg)"};
   }
 `;
 
@@ -199,7 +196,6 @@ export function SidebarNavigation() {
               onClick={() => alert("Support")}
             />
             <CollapseMenuItem
-              isSidebarCollapsed={isSidebarCollapsed}
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}


### PR DESCRIPTION
Refactor code inside sidebar-navigation.tsx to remove 'isSidebarCollapsed' props from 'CollapseMenuItem' component as it was a duplicate of the already existing 'isCollapsed' props.