### PR TITLE
Sidebar Navigation: Wrong logo when switching to mobile view

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
-    "retries": {
-      "runMode": 2,
-      "openMode": 0
-    }
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,6 @@
-{}
+{
+    "retries": {
+      "runMode": 2,
+      "openMode": 0
+    }
+}

--- a/cypress/integration/issue-list.spec.ts
+++ b/cypress/integration/issue-list.spec.ts
@@ -10,23 +10,23 @@ describe("Issue List", () => {
     }).as("getProjects");
     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1", {
       fixture: "issues-page-1.json",
-    }).as("getIssues");
+    }).as("getIssuesPage1");
     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2", {
       fixture: "issues-page-2.json",
-    });
+    }).as("getIssuesPage2");
     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3", {
       fixture: "issues-page-3.json",
-    });
+    }).as("getIssuesPage3");
 
     // open issues page
     cy.visit(`http://localhost:3000/dashboard/issues`);
 
     // wait for request to resolve
-    cy.wait("@getProjects");
-    cy.wait("@getIssues");
+    cy.wait(["@getProjects", "@getIssuesPage1"]);
+    cy.wait(500);
 
     // set button aliases
-    cy.get("button", { timeout: 10000 }).contains("Previous").as("prev-button");
+    cy.get("button").contains("Previous").as("prev-button");
     cy.get("button").contains("Next").as("next-button");
   });
 
@@ -78,6 +78,8 @@ describe("Issue List", () => {
       cy.contains("Page 2 of 3");
 
       cy.reload();
+      cy.wait(["@getProjects", "@getIssuesPage2"]);
+      cy.wait(1500);
       cy.contains("Page 2 of 3");
     });
   });

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -37,6 +37,12 @@ describe("Sidebar Navigation", () => {
         );
     });
 
+    it("checks that large logo is displayed in desktop resolution with nav not collapsed", () => {
+      cy.get("header")
+        .find("img")
+        .should("have.attr", "src", "/icons/logo-large.svg");
+    });
+
     it("is collapsible", () => {
       // collapse navigation
       cy.get("nav").contains("Collapse").click();
@@ -47,6 +53,11 @@ describe("Sidebar Navigation", () => {
 
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
+
+      //check that small logo is displayed in desktop resolution with nav collapsed
+      cy.get("header")
+        .find("img")
+        .should("have.attr", "src", "/icons/logo-small.svg");
     });
   });
 
@@ -96,6 +107,12 @@ describe("Sidebar Navigation", () => {
       cy.get("img[alt='close menu']").click();
       cy.wait(500);
       isNotInViewport("nav");
+    });
+
+    it("checks that large logo is displayed in mobile resolution", () => {
+      cy.get("header")
+        .find("img")
+        .should("have.attr", "src", "/icons/logo-large.svg");
     });
   });
 });

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -6,7 +6,8 @@ import { NavigationContext } from "./navigation-context";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
-import { breakpoint, color, space, zIndex } from "@styles/theme";
+import { breakpoint, color, space, zIndex, theme } from "@styles/theme";
+import { useIsDesktop } from "@hooks/useIsDesktop";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
@@ -152,17 +153,21 @@ const CollapseMenuItem = styled(MenuItemButton)`
   }
 `;
 
+const themeDestkopWidth = parseFloat(theme.breakpoint.desktop) * 16;
+
 export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const isDesktop = useIsDesktop(themeDestkopWidth);
+
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
         <Header>
           <Logo
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && isDesktop
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -153,12 +153,14 @@ const CollapseMenuItem = styled(MenuItemButton)`
   }
 `;
 
-const themeDestkopWidth = parseFloat(theme.breakpoint.desktop) * 16;
+const breakpointDesktop = breakpoint("desktop")({ theme });
+const themeDestkopWidth = parseFloat(breakpointDesktop) * 16;
 
 export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   const isDesktop = useIsDesktop(themeDestkopWidth);
 
   return (

--- a/hooks/useIsDesktop.ts
+++ b/hooks/useIsDesktop.ts
@@ -1,4 +1,4 @@
-import { useWindowWith } from "./useWindowWidth";
+import { useWindowWith } from "@hooks/useWindowWidth";
 
 export function useIsDesktop(desktopWidth: number): boolean {
   const windowWidth = useWindowWith();

--- a/hooks/useIsDesktop.ts
+++ b/hooks/useIsDesktop.ts
@@ -1,0 +1,10 @@
+import { useWindowWith } from "./useWindowWidth";
+
+export function useIsDesktop(desktopWidth: number): boolean {
+  const windowWidth = useWindowWith();
+  if (windowWidth.width && windowWidth.width >= desktopWidth) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/hooks/useWindowWidth.ts
+++ b/hooks/useWindowWidth.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+//define general type for useWindowWith hook, which include width
+interface Width {
+  width: number | undefined;
+}
+
+//Hook
+export function useWindowWith(): Width {
+  //initialization with 'undefined'
+  const [windowWidth, setWindowWidth] = useState<Width>({ width: undefined });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowWidth({ width: window.innerWidth });
+    }
+
+    //add event listener for resize that will trigger handleResize
+    window.addEventListener("resize", handleResize);
+
+    //call handleResize to update state with initial window size
+    handleResize();
+
+    //remove event listener on cleanup
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return windowWidth;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@styles/*": ["styles/*"],
       "@config/*": ["config/*"],
       "@features/*": ["features/*"],
-      "@typings/*": ["typings/*"]
+      "@typings/*": ["typings/*"],
+      "@hooks/*": ["hooks/*"]
     },
     "noEmit": true
   },


### PR DESCRIPTION
Create custom hooks to get window size and advise on isDesktop. 
Logo 'src' is updated based on the viewport